### PR TITLE
Fix circle typo in Rotate option

### DIFF
--- a/Looper.sketchplugin/Contents/Sketch/scripts/panel/table.html
+++ b/Looper.sketchplugin/Contents/Sketch/scripts/panel/table.html
@@ -171,7 +171,7 @@
                                 <div class="form-field vertical_20a">
                                       <label class="mdl-radio mdl-js-radio" for="input_rot_1">
                                         <input checked class="mdl-radio__button" id="input_rot_1" name="rot_radio" type="radio" value='0'>
-                                        <span class="mdl-radio__label">Auto rotate to form a cirlce</span>
+                                        <span class="mdl-radio__label">Auto rotate to form a circle</span>
                                       </label>
 
                                       <label class="mdl-radio mdl-js-radio" for="input_rot_2">


### PR DESCRIPTION
Fixes a minor typo in the 'Auto rotate to form a circle' option within the Rotate section.

Great plugin 👏 